### PR TITLE
fix: set "Help" link in the main menu to AstraX website FAQ page

### DIFF
--- a/extension/src/popup/components/Menu.tsx
+++ b/extension/src/popup/components/Menu.tsx
@@ -143,7 +143,7 @@ export const Menu = () => {
               <a
                 rel="noreferrer"
                 target="_blank"
-                href="http://freighter.app/help"
+                href="https://astraxwallet.com/faq"
               >
                 Help
               </a>


### PR DESCRIPTION
This PR updates the **Help** link in the extension's main menu to go to the URL https://astraxwallet.com/faq. Closes #18 